### PR TITLE
Add teleportation by clicking on full map view

### DIFF
--- a/Content/PersistentBlueprints/Map/Full_Map_Widget.uasset
+++ b/Content/PersistentBlueprints/Map/Full_Map_Widget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:760843d302f9ebe771f4dffb52a7aec916f5907b206a1d6644f2b852f616cbce
-size 62761
+oid sha256:bd6bd80891bdad59ecae8c20aa8c7e45a815bf7b2b07ac4c877ec218d0ff3edd
+size 98000


### PR DESCRIPTION
When in full map view, clicking anywhere on the map will immediatley teleport the player and the currently controlled pawn to the clicked location.