### PR TITLE
Teleport places pawn at reasonable height. Minimap zooms with player height.

### DIFF
--- a/Content/PersistentBlueprints/Map/Full_Map_Widget.uasset
+++ b/Content/PersistentBlueprints/Map/Full_Map_Widget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd6bd80891bdad59ecae8c20aa8c7e45a815bf7b2b07ac4c877ec218d0ff3edd
-size 98000
+oid sha256:fcf1c7896fd648f182f91f455dda2da3bd5f800a200afaa1e3cfe68279a079ea
+size 132828

--- a/Content/PersistentBlueprints/Map/Minimap_Widget.uasset
+++ b/Content/PersistentBlueprints/Map/Minimap_Widget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:85a71000ff16186998d2f63c7dfd74adb6d5b63cbe035caf57748960e44fcced
-size 95457
+oid sha256:ffaa6cb6dabef2ac2ae5c8d692fd483feca7251f546d964f85f9743ab01a6ee3
+size 97091

--- a/Content/PersistentBlueprints/Map/PlayerIcon_Widget.uasset
+++ b/Content/PersistentBlueprints/Map/PlayerIcon_Widget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e1ccdb7e2533dc7122dca11c279d4403dbf738f5d3dd0fe79226477dd58f939e
-size 56327
+oid sha256:b1e0c28c0416258a79107279084108e1f5b7f5112128d40e70477e1cbd6606d2
+size 57842


### PR DESCRIPTION
When teleporting with the map, place the teleported pawn just above the tallest collision object at the clicked location.
Zoom the minimap as the player moves up and down in the world.
Fixes a bug where the player icon on the map blocked short-distance teleports.