### PR TITLE
Show camera orbs in OSC output

### DIFF
--- a/Content/PersistentBlueprints/TextBox_Widget.uasset
+++ b/Content/PersistentBlueprints/TextBox_Widget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44468663960a4a80ea2bb5fc728f13670e99e4b4ed7eca3d19afa51333e86c41
-size 115715
+oid sha256:bac4cba1ba8bd9a44bb7ad405a7d8a1c689715b05a364c0ec05b807f161f8ad2
+size 172457


### PR DESCRIPTION
Show orbs in OSC output, using label text as their tag. Orbs are not actually tagged yet, so OSC cues won't work -- this is just for demonstration